### PR TITLE
Add black, isort and pyupgrade to pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,16 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: [ --py37-plus ]
+  - repo: https://github.com/PyCQA/isort
+    rev: v5.11.3
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black

--- a/src/jinja2_slug/core.py
+++ b/src/jinja2_slug/core.py
@@ -8,5 +8,5 @@ def slug(value):
 
 class SlugExtension(Extension):
     def __init__(self, environment):
-        super(SlugExtension, self).__init__(environment)
-        environment.filters['slug'] = slug
+        super().__init__(environment)
+        environment.filters["slug"] = slug

--- a/tests/test_slug.py
+++ b/tests/test_slug.py
@@ -1,19 +1,20 @@
 import pytest
-
-
 from jinja2 import Environment
 
 
 @pytest.fixture
 def environment():
-    return Environment(extensions=['jinja2_slug.SlugExtension'])
+    return Environment(extensions=["jinja2_slug.SlugExtension"])
 
 
-@pytest.mark.parametrize('input,expected', [
-    ('Motörhead Gang', 'motorhead-gang'),
-    ('This is a Test', 'this-is-a-test')
-])
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("Motörhead Gang", "motorhead-gang"),
+        ("This is a Test", "this-is-a-test"),
+    ],
+)
 def test_slug(input, expected, environment):
-    template = environment.from_string('{{ ' + '"' + input + '"' + '|slug }}')
+    template = environment.from_string("{{ " + '"' + input + '"' + "|slug }}")
 
     assert template.render() == expected


### PR DESCRIPTION
- Setup more pre-commit hooks: pyupgrade, isort and black
- Update flake8 config to match black's max line length of 88 chars
- Run them on the whole code to fix existing issues